### PR TITLE
template: fix path to jquery-ui modules

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -188,9 +188,9 @@
         {% block bodyJavascripts %}
             {% javascripts filter='?closure'
                 '../components/jquery-ui/jquery-ui.js'
-                '../components/jquery-ui/ui/sortable.js'
+                '../components/jquery-ui/ui/widgets/sortable.js'
                 '../components/jquery-ui/ui/effect.js'
-                '../components/jquery-ui/ui/effect-highlight.js'
+                '../components/jquery-ui/ui/effects/effect-highlight.js'
                 '../components/masonry/masonry.pkgd.js'
                 '../components/moment/moment.js'
                 '../components/moment/locale/fr.js'


### PR DESCRIPTION
Some JS files from the jquery UI library have been moved. This PR fixes their path otherwise the minification won't work with a clean installation.