### PR TITLE
docs: move SQL sessions schema to its own file

### DIFF
--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -307,14 +307,7 @@ value   = k=rsa; p=[PUBLIC KEY HERE]
 
 ### Build session table
 
-``` bash
-CREATE TABLE `sessions` (
-    `sess_id` VARCHAR(128) NOT NULL PRIMARY KEY,
-    `sess_data` BLOB NOT NULL,
-    `sess_time` INTEGER UNSIGNED NOT NULL,
-    `sess_lifetime` MEDIUMINT NOT NULL
-) COLLATE utf8_bin, ENGINE = InnoDB;
-```
+Execute the SQL script located at [`database/schema-sessions.sql`](database/schema-sessions.sql).
 
 ## Step 8 - Compile and Minimize CSS and JS
 

--- a/docs/database/schema-sessions.sql
+++ b/docs/database/schema-sessions.sql
@@ -1,0 +1,8 @@
+-- Schema for sessions
+
+CREATE TABLE `sessions` (
+    `sess_id` VARCHAR(128) NOT NULL PRIMARY KEY,
+    `sess_data` BLOB NOT NULL,
+    `sess_time` INTEGER UNSIGNED NOT NULL,
+    `sess_lifetime` MEDIUMINT NOT NULL
+) COLLATE utf8_bin, ENGINE = InnoDB;


### PR DESCRIPTION
Move the SQL script to its own file to ease the setup with automation tools.