### PR TITLE
Fix label error in User/showQuestions.html

### DIFF
--- a/src/Ladb/CoreBundle/Resources/views/Core/User/showQuestions.html.twig
+++ b/src/Ladb/CoreBundle/Resources/views/Core/User/showQuestions.html.twig
@@ -7,7 +7,7 @@
     {% if questions.count == 0 and filter != 'draft' %}
         <div class="alert alert-info ladb-margin-top">
             {% if is_granted("ROLE_USER") and user.id == app.user.id %}
-                <p>Vous n'avez pas encore publié de <strong>trouvaille</strong> !</p>
+                <p>Vous n'avez pas encore publié de <strong>question</strong> !</p>
                 <p><a href="{{ path('core_qa_question_new') }}" class="btn btn-primary"><i class="ladb-icon-plus"></i> {{ 'qa.question.new'|trans() }}</a></p>
             {% else %}
                 <strong>{{ user.username }}</strong> n'a pas encore publié de question.


### PR DESCRIPTION
The line break at the end of file have been added by Github text editor. I'm sorry about it. Feel free to reject my PR and fix this bug directly by yourself if you don't want to add the line break.