### PR TITLE
doc: improve nginx configuration and certbot setup

### DIFF
--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -220,7 +220,24 @@ This will auto generate the `app/config/parameters.yml` file.
 
 Now you are ready to configure Nginx to access to the webroot directory.
 
-## Step 5 - Setup the virtual host on Nginx
+## Step 5 - Generate HTTPS certificates (Not necessary on the **DEV** server)
+
+First you need to install certbot. On Debian Stretch we will be using backports repository to get the last version.
+
+``` bash
+    $ sudo echo 'deb http://ftp.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch_backports.list
+    $ sudo aptitude update
+    $ sudo apt-get install certbot -t stretch-backports
+    $ sudo mkdir -p /var/www/.well-known/acme-challenge
+```
+
+You can now generate certificates.
+
+``` bash
+    $ sudo certbot certonly -n --text --agree-tos --expand --authenticator webroot --server https://acme-v02.api.letsencrypt.org/directory --rsa-key-size 4096 --email root@sysnove.fr -d lairdubois.fr -d www.lairdubois.fr -d lairdubois.com -d www.lairdubois.com --webroot-path /var/www
+```
+
+## Step 6 - Setup the virtual host on Nginx
 
 > If you are on the **PROD** server :
 
@@ -241,30 +258,10 @@ Not that the given DEV config is configured for running on MacOS.
     $ service nginx restart
 ```
 
-## Step 6 - Generate HTTPS certificates (Not necessary on the **DEV** server)
-
-First you need to install certbot.
-
-``` bash
-    $ sudo apt-get install certbot
-```
-
-Before generate the certificates, you need to stop NGINX.
-
-``` bash
-    $ sudo service nginx stop
-```
-
-You can now generate certificates.
-
-``` bash
-    $ certbot certonly --standalone --email contact@lairdubois.fr -d lairdubois.fr -d www.lairdubois.fr -d lairdubois.com -d www.lairdubois.com
-```
-
 Restart NGINX.
 
 ``` bash
-    $ sudo service nginx start
+    $ sudo service nginx restart
 ```
 
 ## Step 7 - Generate and configure DKIM keys (Not necessary on the **DEV** server)

--- a/docs/nginx/conf/www.lairdubois.fr.conf
+++ b/docs/nginx/conf/www.lairdubois.fr.conf
@@ -6,6 +6,11 @@ map $http_referer $banned_referer {
     default     0;
 }
 
+map $http_user_agent $banned_agent {
+    default     0;
+    "~https://developers.google.com/./web/snippet/"   1;
+}
+
 upstream websocket {
   server 127.0.0.1:8080;
 }
@@ -27,13 +32,15 @@ server {
     ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DHE+AES128:!ADH:!AECDH:!MD5;
 
     if ($banned_ip) {
-        rewrite ^(.*)$ /maintenance.html last;
-        break;
+        return 444;
     }
     if ($banned_referer) {
-        rewrite ^(.*)$ /maintenance.html last;
-        break;
+        return 444;
     }
+    if ($banned_agent) {
+        return 444;
+    }
+
 
     # strip app.php/ prefix if it is present
     rewrite ^/app\.php/?(.*)$ /$1 permanent;
@@ -111,6 +118,13 @@ server {
 
     error_log /var/log/nginx/www.lairdubois.fr_error.log;
     access_log /var/log/nginx/www.lairdubois.fr_access.log;
+
+    location ~ ^/\.well-known/acme-challenge/(.+)$ {
+        allow all;
+        alias /var/www/.well-known/acme-challenge/$1;
+        log_not_found off;
+        access_log off;
+    }
 }
 
 server {
@@ -132,6 +146,12 @@ server {
         fastcgi_pass    unix:/run/php/php7.2-fpm.sock;
     }
 
+    location ~ ^/\.well-known/acme-challenge/(.+)$ {
+        allow all;
+        alias /var/www/.well-known/acme-challenge/$1;
+        log_not_found off;
+        access_log off;
+    }
 }
 
 server {
@@ -145,6 +165,13 @@ server {
                     *.lairdubois.org;
 
     return          301 https://www.lairdubois.fr$request_uri;
+
+    location ~ ^/\.well-known/acme-challenge/(.+)$ {
+        allow all;
+        alias /var/www/.well-known/acme-challenge/$1;
+        log_not_found off;
+        access_log off;
+    }
 }
 
 server {
@@ -167,4 +194,11 @@ server {
     ssl_ciphers                 ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DHE+AES128:!ADH:!AECDH:!MD5;
 
     return                      301 https://www.lairdubois.fr$request_uri;
+
+    location ~ ^/\.well-known/acme-challenge/(.+)$ {
+        allow all;
+        alias /var/www/.well-known/acme-challenge/$1;
+        log_not_found off;
+        access_log off;
+    }
 }


### PR DESCRIPTION
Install certbot before Nginx
Install certbot from stretch-backports
Configure Nginx to manage user agent blacklist