### PR TITLE
~ symfony directories: move cache, vendor and logs directory outisde …

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -50,12 +50,12 @@ class AppKernel extends Kernel
 
 	public function getCacheDir()
 	{
-		return dirname(__DIR__).'/var/cache/'.$this->getEnvironment();
+		return '/var/cache/ladb/'.$this->getEnvironment();
 	}
 
 	public function getLogDir()
 	{
-		return dirname(__DIR__).'/var/logs';
+		return '/var/log/ladb';
 	}
 
 	public function registerContainerConfiguration(LoaderInterface $loader)

--- a/app/autoload.php
+++ b/app/autoload.php
@@ -2,13 +2,13 @@
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
-$loader = require __DIR__.'/../vendor/autoload.php';
+$loader = require '/var/cache/ladb/vendor/autoload.php';
 
 // intl
 if (!function_exists('intl_get_error_code')) {
-    require_once __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs/functions.php';
+    require_once '/var/cache/ladb/vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs/functions.php';
 
-    $loader->add('', __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs');
+    $loader->add('', '/var/cache/ladb/vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs');
 }
 
 AnnotationRegistry::registerLoader(array($loader, 'loadClass'));

--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,8 @@
         ]
     },
     "config": {
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "vendor-dir": "/var/cache/ladb/vendor"
     },
     "extra": {
         "symfony-app-dir": "app",


### PR DESCRIPTION
…of the code source structure

- `var/cache` is now at `/var/cache/ladb`
- `var/logs` is now at `/var/log/ladb`
- `vendor` is now at `/var/cache/ladb/vendor`

Is there a better way to set those directories based on a variable defined in `parameters.yml` file instead of harcoding them in the PHP files ?

## Commands
To migrate the existing directories/files, run as root:
```
mkdir -p /var/cache/ladb/vendor && \
mkdir /var/log/ladb && \
chown -R www-data:www-data /var/cache/ladb /var/log/ladb && \
mv /var/www/www.lairdubois.fr/var/cache/* /var/cache/ladb/ && \
mv /var/www/www.lairdubois.fr/var/logs/* /var/log/ladb/ && \
mv /var/www/www.lairdubois.fr/vendor/* /var/cache/ladb/vendor/
```