### PR TITLE
Add missing translation for new schools in mailing 'weeknews'

### DIFF
--- a/src/Ladb/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Ladb/CoreBundle/Resources/translations/messages.fr.yml
@@ -826,6 +826,7 @@ knowledge:
       edit: Editer mon témoignage
     choice:
       entities: '[0,1]école|]1,Inf]écoles'
+      new_schools: '[0,1]nouvelle école|]1,Inf]nouvelles écoles'
       testimonials: '[0,1]témoignage|]1,Inf]témoignages'
   book:
     description: Catalogue collaboratif de livres sur la matière et le travail du bois.


### PR DESCRIPTION
I received the week's news on December 6th, and I noticed that a translation was missing: **knowledge.school.choice.new_schools**

![Capture du 2019-12-13 18:09:50](https://user-images.githubusercontent.com/361876/70818360-c940e600-1dd3-11ea-87c5-00ebf95cae2e.png)

Note: I have not tested this change on a locally built site.
