### PR TITLE
Add dot to allowed characters in Instagram username

### DIFF
--- a/src/Ladb/CoreBundle/Entity/Core/UserMeta.php
+++ b/src/Ladb/CoreBundle/Entity/Core/UserMeta.php
@@ -87,7 +87,7 @@ class UserMeta {
 
 	/**
 	 * @ORM\Column(type="string", length=50, nullable=true)
-	 * @Assert\Regex("/^[a-zA-Z0-9_]+$/")
+	 * @Assert\Regex("/^[a-zA-Z0-9_.]+$/")
 	 */
 	private $instagram;
 


### PR DESCRIPTION
Le site ne permet pas d'ajouter un compte Instagram qui contient un point alors que c'est autorisé chez Instagram.
