### PR TITLE
Typos & rewording

### DIFF
--- a/src/Ladb/CoreBundle/Resources/views/Funding/_dashboard.part.html.twig
+++ b/src/Ladb/CoreBundle/Resources/views/Funding/_dashboard.part.html.twig
@@ -76,9 +76,9 @@
                         <i class="ladb-icon-info ladb-icon-lg"></i>
                     </div>
                     <div class="media-body">
-                        <p>Attention que le maintient et le développement d'une plateforme comme <em>L'Air du Bois</em> ne peut pas se résumer au coût de <strong>{{ funding.outgoingsBalanceEur|number_format(2, ',', ' ') }}€</strong> par mois.</p>
+                        <p>Attention, le maintien et le développement d'une plateforme comme <em>L'Air du Bois</em> ne peut pas se résumer au coût de <strong>{{ funding.outgoingsBalanceEur|number_format(2, ',', ' ') }}€</strong> par mois.</p>
                         <p>Ne sont comptabilisés ici que les frais fixes facturés par des prestataires externes.</p>
-                        <p>Le plus gros de l'effort est collectif et <strong>bénévole</strong> et cache des dons de soi bien suppérieurs pour tous les contributeurs à ce projet.</p>
+                        <p>Le plus gros de l'effort est collectif et <strong>bénévole</strong> et cache des dons de soi bien supérieurs pour tous les contributeurs à ce projet.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- maintien n'a pas de t (ne pas confondre le nom "maintien" et le verbe conjugué à la 3è personne "maintient")
- supérieurs n'a qu'un p
- "Attention que" n'est pas correct, j'ai remplacé par un simple "Attention, ", on pourrait aussi mettre "Attention : " voire réécrire sans "Attention" du tout.