### PR TITLE
Remove IDE directories from project gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,3 @@
 /keys/
 /vendor
 /composer.phar
-.idea
-.DS_Store


### PR DESCRIPTION
Les fichiers/dossiers générés par les IDE et les OS ne devraient pas se trouver dans le `.gitignore` du projet, sinon ça peut rapidement devenir la foire aux IDE.

La _best practice_ est de configurer ça dans le `.gitignore` de son poste, dans `~/.gitignore` par exemple.