### PR TITLE
Update showCreations.html.twig

### DIFF
--- a/src/Ladb/CoreBundle/Resources/views/Core/User/showCreations.html.twig
+++ b/src/Ladb/CoreBundle/Resources/views/Core/User/showCreations.html.twig
@@ -3,32 +3,58 @@
 {% set masonry = true %}
 
 {% block bodyContainerContent %}
-    {% if creations.count == 0 and filter != 'draft' %}
-        <div class="alert alert-info ladb-margin-top">
-            {% if is_granted("ROLE_USER") and user.id == app.user.id %}
+    {% if is_granted("ROLE_USER") and user.id == app.user.id %}
+        {% if creations.count == 0 and filter != 'draft' %}
+            {% if filter=='recent'%}
                 <p>Vous n'avez pas encore publié de <strong>création</strong> !</p>
+                <p><a href="{{ path('core_creation_new') }}" class="btn btn-primary"><i class="ladb-icon-plus"></i> {{ 'wonder.creation.new'|trans() }}</a></p>   
+            {% else  %}
+                <p>Vous n'avez pas de <strong>création</strong> dans cette catégorie!</p>
                 <p><a href="{{ path('core_creation_new') }}" class="btn btn-primary"><i class="ladb-icon-plus"></i> {{ 'wonder.creation.new'|trans() }}</a></p>
-            {% else %}
-                <strong>{{ user.username }}</strong> n'a pas encore publié de création.
             {% endif %}
-        </div>
+        {% else %}
+            {% embed 'LadbCoreBundle:Wonder/Creation:_list-filterbar.part.html.twig' %}
+                {% set filterPath = 'core_user_show_creations_filter' %}
+                {% set filterPathParameters = { 'username':user.usernameCanonical } %}
+                {% set customFilterDefs = {
+                    'draft':    { 'label':('default.choice.draft'|transchoice(2)|capitalize), 'path':path('core_user_show_creations_filter', { 'username':user.usernameCanonical, 'filter':'draft' }), 'hidden':(not isDraftVisible) },
+                } %}
+                {% block filterbarRightContent%}
+                    <span class="ladb-heading">
+                        {% if filter == 'draft' and isDraftVisible %}
+                            {{ user.meta.privateCreationCount~' '~('default.choice.draft'|transchoice(user.meta.privateCreationCount)) }}
+                        {% else %}
+                            {{ user.meta.publicCreationCount }} {{ 'wonder.creation.choice.entities'|transchoice(user.meta.publicCreationCount) }}{% if isDraftVisible and user.meta.privateCreationCount > 0 %} (+{{ user.meta.privateCreationCount~' '~('default.choice.draft'|transchoice(user.meta.privateCreationCount)) }}){% endif %}
+                        {% endif %}
+                    </span>
+                {% endblock %}
+            {% endembed %}
+        {% endif %}
     {% else %}
-        {% embed 'LadbCoreBundle:Wonder/Creation:_list-filterbar.part.html.twig' %}
-            {% set filterPath = 'core_user_show_creations_filter' %}
-            {% set filterPathParameters = { 'username':user.usernameCanonical } %}
-            {% set customFilterDefs = {
-                'draft':    { 'label':('default.choice.draft'|transchoice(2)|capitalize), 'path':path('core_user_show_creations_filter', { 'username':user.usernameCanonical, 'filter':'draft' }), 'hidden':(not isDraftVisible) },
-            } %}
-            {% block filterbarRightContent%}
-                <span class="ladb-heading">
-                    {% if filter == 'draft' and isDraftVisible %}
-                        {{ user.meta.privateCreationCount~' '~('default.choice.draft'|transchoice(user.meta.privateCreationCount)) }}
-                    {% else %}
-                        {{ user.meta.publicCreationCount }} {{ 'wonder.creation.choice.entities'|transchoice(user.meta.publicCreationCount) }}{% if isDraftVisible and user.meta.privateCreationCount > 0 %} (+{{ user.meta.privateCreationCount~' '~('default.choice.draft'|transchoice(user.meta.privateCreationCount)) }}){% endif %}
-                    {% endif %}
-                </span>
-            {% endblock %}
-        {% endembed %}
+        {% if creations.count == 0 and filter != 'draft' %}
+            {% if filter=='popular'%}
+                <strong>{{ user.username }}</strong> n'a pas encore publié de création.
+            {% else  %}
+                <strong>{{ user.username }}</strong> n'a pas de création dans cette catégorie.
+            {% endif %}
+        {% else %}
+            {% embed 'LadbCoreBundle:Wonder/Creation:_list-filterbar.part.html.twig' %}
+                {% set filterPath = 'core_user_show_creations_filter' %}
+                {% set filterPathParameters = { 'username':user.usernameCanonical } %}
+                {% set customFilterDefs = {
+                    'draft':    { 'label':('default.choice.draft'|transchoice(2)|capitalize), 'path':path('core_user_show_creations_filter', { 'username':user.usernameCanonical, 'filter':'draft' }), 'hidden':(not isDraftVisible) },
+                } %}
+                {% block filterbarRightContent%}
+                    <span class="ladb-heading">
+                        {% if filter == 'draft' and isDraftVisible %}
+                            {{ user.meta.privateCreationCount~' '~('default.choice.draft'|transchoice(user.meta.privateCreationCount)) }}
+                        {% else %}
+                            {{ user.meta.publicCreationCount }} {{ 'wonder.creation.choice.entities'|transchoice(user.meta.publicCreationCount) }}{% if isDraftVisible and user.meta.privateCreationCount > 0 %} (+{{ user.meta.privateCreationCount~' '~('default.choice.draft'|transchoice(user.meta.privateCreationCount)) }}){% endif %}
+                        {% endif %}
+                    </span>
+                {% endblock %}
+            {% endembed %}
+         {% endif %}
     {% endif %}
     {{ parent() }}
 {% endblock %}


### PR DESCRIPTION
En tenant compte du message Boris sur #73.
Les conditions ont permis de différencier trois variables successivement.

1. Est-ce l'utilisateur courant ou non ?
2. A-t'il des créations ?
3. S'il a des créations, en a-t'il dans la catégorie filtrée ?

Cela a permis de préciser un peu les messages dans chacune des six possibilités.

1. if current user and 0 creations -> no filter bar + "you have no creations" message
2. if current user and 0 creations in filtered category (e.g. other than "recent" which is default) -> add filter bar + "you have no creations in this category" message
3. if current user with creations -> Filter bar + list of creations
4. if other user and 0 creations -> No filter + "user has no creations" messages
5. if other user and 0 creations in filtered category (other than "popular" which is default) -> No filter + "user has no creations in this category" messages
6. if other user with creations -> Filter bar + His list of creations

Pas de possibilité de le tester sur mon ordinateur, mais c'est une nouvelle proposition pour gérer les différents scenarii. Il y aurait plein d'autres manières de le faire, mais celle-ci me semblait la plus logique bien qu'elle nécessite deux {% embed %}