### PR TITLE
Fix default path of Chromium binary

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -39,7 +39,7 @@ parameters:
     node:                           /usr/bin/node
     node_paths:                     [/usr/local/lib/node_modules/]
 
-    chromium:                       /urs/bin/chromium
+    chromium:                       /usr/bin/chromium
 
     google_api_key:                 YOUR_GOOGLE_API_KEY
 


### PR DESCRIPTION
Bonjour,

Pendant mon travail sur https://github.com/lairdubois/lairdubois/pull/68, j'ai réinstallé le projet complètement un paquet de fois. Et souvent j'ai eu droit à une erreur lors de la création d'une trouvaille, comme quoi il ne trouvait l'exécutable chromium pour générer la vignette.

En y regardant de plus près, je suspecte une faute de frappe sur le _path_ par défaut.

Qu'en dis-tu @bbeaulant ?