### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,100 @@
+SHELL=bash
+
+DOCKER_COMPOSE  = docker-compose
+
+EXEC_JS         = node
+EXEC_DB         = $(DOCKER_COMPOSE) exec -T mariadb
+EXEC_QA         = $(DOCKER_COMPOSE) run -T -e APP_ENV=test --rm symfony
+EXEC_PHP        = $(DOCKER_COMPOSE) exec symfony docker-php-entrypoint
+RUN_PHP         = $(DOCKER_COMPOSE) run --entrypoint docker-php-entrypoint symfony
+
+SYMFONY_CONSOLE = $(EXEC_PHP) php bin/console
+COMPOSER        = $(RUN_PHP) composer
+YARN            = yarn
+
+DB_USER = root
+DB_PWD = root
+
+CURRENT_DATE = `date "+%Y-%m-%d_%H-%M-%S"`
+
+# Helper variables
+_TITLE := "\033[32m[%s]\033[0m %s\n" # Green text
+_ERROR := "\033[31m[%s]\033[0m %s\n" # Red text
+
+##
+## General purpose commands
+## ────────────────────────
+##
+
 .DEFAULT_GOAL := help
+help: ## Show this help message
+	@grep -E '(^[a-zA-Z_-]+:.*?##.*$$)|(^##)' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf " \033[32m%-25s\033[0m%s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'
+.PHONY: help
 
-help:
-	@grep -E '(^[a-zA-Z_-]+:.*?##.*$$)|(^##)' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'
+install: docker-compose.override.yml build node_modules start vendor db test-db assets ## Install the project
 
-clean:
-	@docker-compose down --remove-orphans
+docker-compose.override.yml:
+	cp docker-compose.override.yml.dist docker-compose.override.yml
 
-clean.all: ## Kill containers and remove volumes
-	@docker-compose down --remove-orphans --volumes
+start: ## Start all containers
+	@$(DOCKER_COMPOSE) up -d --remove-orphans --no-recreate
+.PHONY: start
 
-install: ## Initialize project & start all containers
-	@cp docker-compose.override.yml.dist docker-compose.override.yml						# Copy default custom docker composer configuration
-	@cp .env .env.local																		# Copy default custom symfony environment vars
-	@docker-compose up -d --build --force-recreate
-	@docker-compose exec symfony composer install -o -n										# Install symfony components
-	@docker-compose exec symfony bin/console doctrine:database:create --if-not-exists		# Create database
-	@docker-compose exec symfony bin/console doctrine:schema:update --force					# Update database schema
-	@docker-compose exec symfony bin/console fos:elastica:reset-templates					# Reset elasticsearche templates
-	@docker-compose exec symfony bin/console fos:elastica:reset								# Reset elasticsearch indices
-	@docker-compose exec symfony yarn encore dev											# Build assets
+stop: ## Stop all containers
+	@$(DOCKER_COMPOSE) stop
+.PHONY: stop
 
-start: ## Starts dev stack
-	@docker-compose start
+build:
+	@$(DOCKER_COMPOSE) pull --include-deps
+	@$(DOCKER_COMPOSE) build --force-rm --compress
+.PHONY: build
 
-stop: ## Stops dev stack
-	@docker-compose stop
+vendor: ## Install PHP vendors
+	$(COMPOSER) install
+.PHONY: vendor
+
+node_modules:
+	@mkdir -p public/build/
+	$(YARN) install
+.PHONY: node_modules
+
+wait-for-db:
+	@echo " Waiting for database..."
+	@for i in {1..5}; do $(EXEC_DB) mysql -u$(DB_USER) -p$(DB_PWD) -e "SELECT 1;" > /dev/null 2>&1 && sleep 1 || echo " Unavailable..." ; done;
+.PHONY: wait-for-db
+
+db: dev-db migrations ## Reset the development database
+.PHONY: db
+
+dev-db: wait-for-db
+	-$(SYMFONY_CONSOLE) doctrine:database:drop --if-exists --force
+	-$(SYMFONY_CONSOLE) doctrine:database:create --if-not-exists
+.PHONY: dev-db
+
+test-db: wait-for-db ## Create a database for testing
+	@echo "doctrine:database:drop"
+	@APP_ENV=test $(SYMFONY_CONSOLE) --env=test doctrine:database:drop --if-exists --force
+	@echo "doctrine:database:create"
+	@APP_ENV=test $(SYMFONY_CONSOLE) --env=test doctrine:database:create
+	@echo "doctrine:schema:create"
+	@APP_ENV=test $(SYMFONY_CONSOLE) --env=test doctrine:migrations:migrate --no-interaction --allow-no-migration
+.PHONY: test-db
+
+migrations:
+	$(SYMFONY_CONSOLE) doctrine:migrations:migrate --no-interaction --allow-no-migration
+.PHONY: migrations
+
+assets: node_modules ## Run Webpack to compile assets
+	@mkdir -p public/build/
+	$(YARN) run dev
+.PHONY: assets
+
+##
+## Project-specific commands
+## ─────────────────────────
+##
+
+elastic: ## Populate ElasticSearch database
+	$(SYMFONY_CONSOLE) fos:elastica:reset-templates
+	$(SYMFONY_CONSOLE) fos:elastica:reset
+.PHONY: elastic


### PR DESCRIPTION
Bon, alors quelques explications sur ce "gros" makefile :

* Il est inspiré du Makefile que j'utilise sur quasiment tous mes projets. Le dernier en date est open source et est [ici](https://github.com/Pierstoval/CorahnRin/blob/main/Makefile)
* Il découpe les différentes actions nécessaires à l'installation du projet en plusieurs _target_, dont quelques-uns sont visibles juste avec le message d'aide quand on exécute `make`. L'intérêt est de pouvoir plus facilement débugguer certains cas spécifiques. Genre `make dev-db` quand on a un problème avec juste la bdd de dev. Ou `make vendor` pour réinstaller les dépendances composer, etc.
* Les commandes spécifiques au projet (et qu'on évitera de copier/coller si on réutilise ce Makefile) sont tout en bas du Makefile. Pour l'instant, seules les commandes liées à ElasticSearch sont dedans.
* On peut y voir l'instruction `.PHONY` un peu partout, et d'autres trucs. J'ai déjà écrit des articles de blog sur ce sujet qui expliquent le fonctionnement du Makefile dans ce contexte, vous pouvez lire ça [ici](https://www.orbitale.io/fr/2019/09/16/comment-j-ai-migre-tout-mon-travail-sous-docker-acte-IV-compose.html#un-makefile-de-base-pour-un-projet-php-avec-docker-compose) (c'est rapide à lire, je rassure 😉)